### PR TITLE
The Code::TidyAll::Result object has no msg attribute

### DIFF
--- a/lib/Dist/Zilla/Plugin/TidyAll.pm
+++ b/lib/Dist/Zilla/Plugin/TidyAll.pm
@@ -35,7 +35,7 @@ sub munge_file {
     my $path   = $file->name;
     my $result = $self->tidyall->process_source( $source, $path );
     if ( $result->error ) {
-        die $result->msg;
+        die $result->error;
     }
     elsif ( $result->state eq 'tidied' ) {
         my $destination = $result->new_contents;


### PR DESCRIPTION
We should use `error` instead.

BTW, if you want me to release this module, I'd be up for that. In that case, it'd be great if you could transfer this repo to the autarch-code organization.
